### PR TITLE
Added unit test running action.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,8 +17,35 @@ permissions:
   contents: read
 
 jobs:
-  release-build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest polars pyarrow
+          python -m pip install -e .
+
+      - name: Run tests
+        run: |
+          python -m pytest -v
+
+  release-build:
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_version.outputs.package_version }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/python-publish.yml` workflow to introduce automated testing for multiple Python versions and ensure that the release build only runs after successful tests. The main changes are grouped below:

**Continuous Integration improvements:**

* Added a `test` job that runs on Ubuntu and tests the codebase against Python 3.10, 3.11, and 3.12 using `pytest`. This job installs dependencies (`pytest`, `polars`, `pyarrow`) and runs tests for each Python version in the matrix.

**Release process enhancements:**

* Updated the `release-build` job to depend on the `test` job, ensuring that releases only happen after tests pass. Also added an output for the `package_version` from the `get_version` step