### PR TITLE
feat: Add optional MLflow experiment tracking integration

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -20,13 +20,14 @@ The Bukka CLI provides a robust interface for creating machine learning project 
 - ✅ YAML configuration files
 - ✅ Multiple dataframe backends (Polars, Pandas, Modin, cuDF, Dask, PyArrow)
 - ✅ Problem type specification (classification, regression, clustering)
+- ✅ MLflow experiment tracking integration
 - ✅ Comprehensive input validation
 - ✅ Detailed help documentation
 
 ## Installation
 
 ```bash
-pip install -e .
+pip install bukka
 ```
 
 Make sure PyYAML is installed (it's included in the dependencies).
@@ -68,6 +69,8 @@ python -m bukka run [OPTIONS]
 - `--dataset, -d`: Path to dataset file (CSV, Parquet, etc.)
 - `--target, -t`: Name of the target column (omit for clustering)
 - `--skip-venv, -sv`: Skip virtual environment creation
+- `--mlflow`: Enable MLflow experiment tracking
+- `--mlflow-tracking-uri`: MLflow tracking URI (default: mlruns/ in project directory)
 
 **Data Processing:**
 - `--backend, -b`: Dataframe backend (default: polars)
@@ -99,6 +102,8 @@ project:
   dataset: data/train.csv
   target: target_column
   skip_venv: false
+  enable_mlflow: false  # Enable MLflow experiment tracking
+  mlflow_tracking_uri: null  # Optional: custom MLflow tracking URI
 
 # Data processing settings
 data:
@@ -174,6 +179,24 @@ python -m bukka run --config my_config.yaml
 ```bash
 python -m bukka run -n stratified_proj -d data.csv -t outcome \
   --strata gender age_group --backend polars
+```
+
+### 8. Enable MLflow experiment tracking
+
+```bash
+python -m bukka run -n tracked_project -d data.csv -t target \
+  --mlflow --backend polars
+```
+
+MLflow will be configured automatically with:
+- Tracking URI: `file:///mlruns` in your project directory
+- Experiment name: `{project_name}_experiment`
+- MLflow setup file: `mlflow_setup.py` for easy configuration
+
+After project creation, view your experiments with:
+```bash
+cd tracked_project
+mlflow ui
 ```
 
 ## Input Validation

--- a/src/bukka/__main__.py
+++ b/src/bukka/__main__.py
@@ -223,6 +223,17 @@ For more information, visit: https://github.com/pjachim/Bukka
         action='store_true',
         help='Skip virtual environment creation'
     )
+    project_group.add_argument(
+        '--mlflow',
+        dest='enable_mlflow',
+        action='store_true',
+        help='Enable MLflow experiment tracking'
+    )
+    project_group.add_argument(
+        '--mlflow-tracking-uri',
+        type=str,
+        help='MLflow tracking URI (default: mlruns/ in project directory)'
+    )
     
     # Data processing settings
     data_group = run_parser.add_argument_group('data processing')

--- a/src/bukka/cli_config.py
+++ b/src/bukka/cli_config.py
@@ -28,6 +28,8 @@ DEFAULT_CONFIG = {
         "dataset": None,
         "target": None,
         "skip_venv": False,
+        "enable_mlflow": False,
+        "mlflow_tracking_uri": None,
     },
     "data": {
         "backend": "polars",
@@ -71,6 +73,8 @@ class BukkaConfig:
     dataset: str | None = None
     target: str | None = None
     skip_venv: bool = False
+    enable_mlflow: bool = False
+    mlflow_tracking_uri: str | None = None
     
     # Data settings
     backend: str = "polars"
@@ -129,6 +133,8 @@ class BukkaConfig:
             dataset=get_value('dataset', ('project', 'dataset')),
             target=get_value('target', ('project', 'target')),
             skip_venv=get_value('skip_venv', ('project', 'skip_venv'), False),
+            enable_mlflow=get_value('enable_mlflow', ('project', 'enable_mlflow'), False),
+            mlflow_tracking_uri=get_value('mlflow_tracking_uri', ('project', 'mlflow_tracking_uri')),
             backend=get_value('backend', ('data', 'backend'), 'polars'),
             train_size=get_value('train_size', ('data', 'train_size'), 0.8),
             stratify=get_value('stratify', ('data', 'stratify'), True),
@@ -186,6 +192,8 @@ class BukkaConfig:
             'dataset_path': self.dataset,
             'target_column': self.target,
             'skip_venv': self.skip_venv,
+            'enable_mlflow': self.enable_mlflow,
+            'mlflow_tracking_uri': self.mlflow_tracking_uri,
             'backend': self.backend,
             'problem_type': self.problem_type,
             'train_size': self.train_size,
@@ -383,6 +391,8 @@ project:
   dataset: null  # Path to your dataset file (CSV, Parquet, etc.)
   target: null  # Name of the target column in your dataset
   skip_venv: {DEFAULT_CONFIG['project']['skip_venv']}  # Skip virtual environment creation
+  enable_mlflow: {DEFAULT_CONFIG['project']['enable_mlflow']}  # Enable MLflow experiment tracking
+  mlflow_tracking_uri: null  # MLflow tracking URI (default: mlruns/ in project)
 
 # Data processing settings
 data:

--- a/src/bukka/coding/write_config.py
+++ b/src/bukka/coding/write_config.py
@@ -18,7 +18,8 @@ class ConfigWriter:
     Generates and writes a configuration file for a Bukka project.
 
     This class constructs a Python source file containing configuration settings
-    for the Bukka project, such as the DataFrame backend to use.
+    for the Bukka project, such as the DataFrame backend to use and optional
+    MLflow configuration.
 
     Parameters
     ----------
@@ -26,27 +27,43 @@ class ConfigWriter:
         The file path where the configuration file will be written.
     backend_name : str
         The name of the DataFrame backend to use (e.g., 'pandas', 'polars').
+    file_manager : FileManager
+        Manager for project file paths and directory structure.
+    enable_mlflow : bool, optional
+        Whether to include MLflow configuration (default: False).
+    mlflow_tracking_uri : str | None, optional
+        MLflow tracking URI. If None and enable_mlflow is True,
+        defaults to mlruns directory (default: None).
 
     Examples
     --------
-    >>> writer = ConfigWriter(output_path="config.py", backend_name="pandas")
+    >>> writer = ConfigWriter(output_path="config.py", backend_name="pandas", file_manager=fm)
     >>> writer.write_config()  # Writes the config file with pandas backend
     """
-    def __init__(self, output_path: str, backend_name: str, file_manager: FileManager):
+    def __init__(
+        self,
+        output_path: str,
+        backend_name: str,
+        file_manager: FileManager,
+        enable_mlflow: bool = False,
+        mlflow_tracking_uri: str | None = None
+    ):
         self.output_path = output_path
         self.backend_name = backend_name
         self.file_manager = file_manager
+        self.enable_mlflow = enable_mlflow
+        self.mlflow_tracking_uri = mlflow_tracking_uri
 
     def write_config(self) -> None:
         """
         Write the configuration file to the configured output path.
 
         Generates Python source code from the template and writes it to
-        the specified file.
+        the specified file. Conditionally includes MLflow configuration.
 
         Examples
         --------
-        >>> writer = ConfigWriter(output_path="config.py", backend_name="polars")
+        >>> writer = ConfigWriter(output_path="config.py", backend_name="polars", file_manager=fm)
         >>> writer.write_config()  # Writes the config file with polars backend
         """
         config_code = CONFIG_TEMPLATE.format(
@@ -54,5 +71,20 @@ class ConfigWriter:
             train_relative_path=self.file_manager.train_file_relative_path.as_posix(),
             test_relative_path=self.file_manager.test_file_relative_path.as_posix()
         )
+        
+        # Append MLflow configuration if enabled
+        if self.enable_mlflow:
+            if self.mlflow_tracking_uri is None:
+                tracking_uri = f"file:///{self.file_manager.mlruns_path.as_posix()}"
+            else:
+                tracking_uri = self.mlflow_tracking_uri
+            
+            mlflow_config = f'''
+# MLflow Configuration
+MLFLOW_TRACKING_URI = "{tracking_uri}"
+MLFLOW_EXPERIMENT_NAME = "{self.file_manager.project_path.name}_experiment"
+'''
+            config_code += mlflow_config
+        
         with open(self.output_path, 'w') as file:
             file.write(config_code)

--- a/src/bukka/coding/write_mlflow_setup.py
+++ b/src/bukka/coding/write_mlflow_setup.py
@@ -1,0 +1,110 @@
+"""MLflow setup file generator for Bukka projects.
+
+This module creates a setup file for MLflow experiment tracking integration.
+"""
+from pathlib import Path
+from bukka.coding.utils.template_handler import TemplateBaseClass
+from bukka.utils.files.file_manager import FileManager
+
+
+MLFLOW_SETUP_TEMPLATE = '''"""MLflow experiment tracking configuration.
+
+This module provides MLflow configuration and setup for tracking machine learning experiments.
+"""
+import mlflow
+from pathlib import Path
+
+
+# MLflow configuration
+MLFLOW_TRACKING_URI = "{tracking_uri}"
+MLFLOW_EXPERIMENT_NAME = "{experiment_name}"
+
+
+def setup_mlflow() -> mlflow:
+    """Initialize MLflow tracking with project configuration.
+    
+    Sets the tracking URI and experiment name for the current project.
+    
+    Returns
+    -------
+    mlflow
+        The mlflow module with configured tracking.
+    
+    Examples
+    --------
+    >>> mlflow_client = setup_mlflow()
+    >>> # Start tracking your experiments
+    >>> with mlflow.start_run():
+    ...     mlflow.log_param("alpha", 0.5)
+    ...     mlflow.log_metric("rmse", 0.85)
+    """
+    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+    mlflow.set_experiment(MLFLOW_EXPERIMENT_NAME)
+    return mlflow
+
+
+if __name__ == "__main__":
+    setup_mlflow()
+    print(f"MLflow tracking URI: {{MLFLOW_TRACKING_URI}}")
+    print(f"Experiment: {{MLFLOW_EXPERIMENT_NAME}}")
+    print("\\nTo view experiments, run: mlflow ui")
+'''
+
+
+class MLflowSetupWriter(TemplateBaseClass):
+    """Generates MLflow setup file for a Bukka project.
+    
+    This class creates a Python file that configures MLflow experiment tracking
+    with project-specific settings.
+    
+    Parameters
+    ----------
+    file_manager : FileManager
+        Manager for project file paths and directory structure.
+    project_name : str
+        Name of the project for experiment naming.
+    tracking_uri : str | None, optional
+        MLflow tracking URI. If None, defaults to file-based tracking
+        in the project's mlruns directory.
+    
+    Examples
+    --------
+    >>> from bukka.utils.files.file_manager import FileManager
+    >>> file_manager = FileManager(project_path="my_project", orig_dataset=None)
+    >>> writer = MLflowSetupWriter(file_manager, "my_project")
+    >>> writer.write_code()
+    """
+    
+    def __init__(
+        self,
+        file_manager: FileManager,
+        project_name: str,
+        tracking_uri: str | None = None
+    ):
+        """Initialize the MLflow setup writer.
+        
+        Parameters
+        ----------
+        file_manager : FileManager
+            Manager for project file paths and directory structure.
+        project_name : str
+            Name of the project for experiment naming.
+        tracking_uri : str | None, optional
+            MLflow tracking URI. If None, defaults to file-based tracking
+            in the project's mlruns directory (default: None).
+        """
+        # Default to file-based tracking in mlruns directory
+        if tracking_uri is None:
+            tracking_uri = f"file:///{file_manager.mlruns_path}"
+        
+        kwargs = {
+            "tracking_uri": tracking_uri,
+            "experiment_name": f"{project_name}_experiment"
+        }
+        
+        super().__init__(
+            template=MLFLOW_SETUP_TEMPLATE,
+            output_path=file_manager.mlflow_setup_path,
+            kwargs=kwargs,
+            expected_args=["tracking_uri", "experiment_name"]
+        )

--- a/src/bukka/environment/environment.py
+++ b/src/bukka/environment/environment.py
@@ -15,6 +15,8 @@ class EnvironmentBuilder:
     ----------
     file_manager : FileManager
         Manager for project file paths and directory structure.
+    enable_mlflow : bool, optional
+        Whether to include MLflow in the environment (default: False).
 
     Examples
     --------
@@ -23,8 +25,9 @@ class EnvironmentBuilder:
     >>> env_builder = EnvironmentBuilder(file_manager)
     >>> env_builder.build_environment()
     """
-    def __init__(self, file_manager: FileManager):
+    def __init__(self, file_manager: FileManager, enable_mlflow: bool = False):
         self.file_manager = file_manager
+        self.enable_mlflow = enable_mlflow
 
 
     def build_environment(self):
@@ -63,10 +66,15 @@ class EnvironmentBuilder:
         Write requirements file and install all required packages.
 
         Creates a requirements.txt file with the standard Bukka dependencies
-        and installs them using pip in the virtual environment.
+        and installs them using pip in the virtual environment. Conditionally
+        includes MLflow if enabled.
         """
+        req_str = requirements.strip()
+        if self.enable_mlflow:
+            req_str += '\nmlflow>=2.0.0'
+        
         with open(self.file_manager.requirements_path, 'w') as f:
-            f.write(requirements.strip())
+            f.write(req_str)
 
         cmd_list = [
             str(self.file_manager.python_path),

--- a/src/bukka/project.py
+++ b/src/bukka/project.py
@@ -31,6 +31,10 @@ class Project:
         The name of the target column in the dataset (optional).
     skip_venv : bool, optional
         Whether to skip virtual environment creation. Defaults to False.
+    enable_mlflow : bool, optional
+        Whether to enable MLflow experiment tracking. Defaults to False.
+    mlflow_tracking_uri : str | None, optional
+        MLflow tracking URI (optional). Defaults to file-based tracking in mlruns/.
     backend : str, optional
         Dataframe backend to use (e.g., 'polars', 'pandas'). Defaults to 'polars'.
     problem_type : str, optional
@@ -52,6 +56,15 @@ class Project:
     ...     problem_type="binary_classification"
     ... )
     >>> proj.run()
+    
+    >>> # With MLflow enabled
+    >>> proj = Project(
+    ...     name="tracked_project",
+    ...     dataset_path="data.csv",
+    ...     target_column="target",
+    ...     enable_mlflow=True
+    ... )
+    >>> proj.run()
     """
     def __init__(
             self,
@@ -59,6 +72,8 @@ class Project:
             dataset_path: str | None = None,
             target_column: str | None = None,
             skip_venv: bool = False,
+            enable_mlflow: bool = False,
+            mlflow_tracking_uri: str | None = None,
             backend: str = "polars",
             problem_type: str = "auto",
             train_size: float = 0.8,
@@ -72,6 +87,8 @@ class Project:
             dataset_path: The path to the original dataset file (optional).
             target_column: The name of the target column (optional).
             skip_venv: Whether to skip virtual environment creation.
+            enable_mlflow: Whether to enable MLflow experiment tracking.
+            mlflow_tracking_uri: MLflow tracking URI (optional).
             backend: Dataframe backend to use (default: 'polars').
             problem_type: ML problem type (default: 'auto').
             train_size: Train/test split ratio (default: 0.8).
@@ -83,6 +100,7 @@ class Project:
         logger.debug(f"Target column: {target_column}")
         logger.debug(f"Backend: {backend}")
         logger.debug(f"Problem type: {problem_type}")
+        logger.debug(f"MLflow enabled: {enable_mlflow}")
         
         self.name: str = name
         self.dataset_path: str | None = dataset_path
@@ -90,6 +108,8 @@ class Project:
         self.target_column: str | None = target_column
         self.environ_manager: EnvironmentBuilder | None = None
         self.skip_venv: bool = skip_venv
+        self.enable_mlflow: bool = enable_mlflow
+        self.mlflow_tracking_uri: str | None = mlflow_tracking_uri
         self.backend: str = backend
         self.problem_type: str = problem_type
         self.train_size: float = train_size
@@ -124,6 +144,11 @@ class Project:
             )
             self._write_data_reader_class()
             self._write_config()
+            
+            if self.enable_mlflow:
+                logger.info("MLflow enabled, generating MLflow setup")
+                self._write_mlflow_setup()
+            
             self._write_starter_notebook()
         else:
             logger.debug("No dataset path provided, skipping pipeline generation")
@@ -202,16 +227,39 @@ class Project:
         """Generate and write a configuration file for the project.
 
         This method creates a configuration file (e.g., `config.py`) that
-        contains settings for the project, such as the DataFrame backend to use.
-        The generated file is saved to the project's config folder.
+        contains settings for the project, such as the DataFrame backend to use
+        and optional MLflow configuration.
         """
         writer = ConfigWriter(
             output_path=self.file_manager.config_path,
             backend_name=self.backend,
-            file_manager=self.file_manager
+            file_manager=self.file_manager,
+            enable_mlflow=self.enable_mlflow,
+            mlflow_tracking_uri=self.mlflow_tracking_uri
         )
         writer.write_config()
         logger.info("Configuration file generation complete", format_level='h4')
+    
+    def _write_mlflow_setup(self) -> None:
+        """Generate and write MLflow setup file for the project.
+
+        This method creates an MLflow setup file that configures experiment
+        tracking for the project. The file includes tracking URI configuration
+        and experiment naming.
+        """
+        from bukka.coding.write_mlflow_setup import MLflowSetupWriter
+        
+        writer = MLflowSetupWriter(
+            file_manager=self.file_manager,
+            project_name=self.name,
+            tracking_uri=self.mlflow_tracking_uri
+        )
+        writer.write_code()
+        
+        # Create mlruns directory
+        self.file_manager.mlruns_path.mkdir(exist_ok=True)
+        
+        logger.info("MLflow setup file generation complete", format_level='h4')
 
     def _build_skeleton(self) -> None:
         """
@@ -243,7 +291,8 @@ class Project:
         
         logger.debug("Initializing EnvironmentBuilder")
         self.environ_manager = EnvironmentBuilder(
-            file_manager=self.file_manager
+            file_manager=self.file_manager,
+            enable_mlflow=self.enable_mlflow
         )
         logger.debug("EnvironmentBuilder initialized")
         

--- a/src/bukka/utils/files/file_manager.py
+++ b/src/bukka/utils/files/file_manager.py
@@ -122,6 +122,10 @@ class FileManager:
         self.readme_path: Path = self.project_path / 'README.md'
         self.gitignore_path: Path = self.project_path / '.gitignore'
         self.pyproject_toml_path: Path = self.project_path / 'pyproject.toml'
+        
+        # MLflow paths
+        self.mlruns_path: Path = self.project_path / 'mlruns'
+        self.mlflow_setup_path: Path = self.project_path / 'mlflow_setup.py'
 
     def _make_path(self, path: Path) -> None:
         """

--- a/test/test_coding/test_mlflow_setup.py
+++ b/test/test_coding/test_mlflow_setup.py
@@ -1,0 +1,86 @@
+"""Unit tests for MLflow setup file generation."""
+import pytest
+from pathlib import Path
+from bukka.coding.write_mlflow_setup import MLflowSetupWriter
+from bukka.utils.files.file_manager import FileManager
+
+
+class TestMLflowSetupWriter:
+    """Test cases for MLflowSetupWriter class."""
+    
+    def test_mlflow_setup_writer_initialization(self, tmp_path):
+        """Test MLflowSetupWriter initializes correctly."""
+        # Create a temporary FileManager
+        project_path = tmp_path / "test_project"
+        file_manager = FileManager(project_path=project_path, orig_dataset=None)
+        
+        # Create writer
+        writer = MLflowSetupWriter(
+            file_manager=file_manager,
+            project_name="test_project"
+        )
+        
+        # Verify attributes
+        assert writer.kwargs["experiment_name"] == "test_project_experiment"
+        assert "file:///" in writer.kwargs["tracking_uri"]
+        assert "mlruns" in writer.kwargs["tracking_uri"]
+    
+    def test_mlflow_setup_writer_with_custom_uri(self, tmp_path):
+        """Test MLflowSetupWriter with custom tracking URI."""
+        project_path = tmp_path / "test_project"
+        file_manager = FileManager(project_path=project_path, orig_dataset=None)
+        
+        custom_uri = "http://localhost:5000"
+        writer = MLflowSetupWriter(
+            file_manager=file_manager,
+            project_name="test_project",
+            tracking_uri=custom_uri
+        )
+        
+        assert writer.kwargs["tracking_uri"] == custom_uri
+        assert writer.kwargs["experiment_name"] == "test_project_experiment"
+    
+    def test_mlflow_setup_writer_creates_file(self, tmp_path):
+        """Test that MLflowSetupWriter creates the setup file."""
+        project_path = tmp_path / "test_project"
+        project_path.mkdir()
+        file_manager = FileManager(project_path=project_path, orig_dataset=None)
+        
+        writer = MLflowSetupWriter(
+            file_manager=file_manager,
+            project_name="test_project"
+        )
+        writer.write_code()
+        
+        # Verify file was created
+        assert file_manager.mlflow_setup_path.exists()
+        
+        # Verify content
+        content = file_manager.mlflow_setup_path.read_text()
+        assert "import mlflow" in content
+        assert "MLFLOW_TRACKING_URI" in content
+        assert "MLFLOW_EXPERIMENT_NAME" in content
+        assert "test_project_experiment" in content
+        assert "setup_mlflow" in content
+    
+    def test_mlflow_setup_template_has_required_functions(self, tmp_path):
+        """Test that generated MLflow setup has required functions."""
+        project_path = tmp_path / "test_project"
+        project_path.mkdir()
+        file_manager = FileManager(project_path=project_path, orig_dataset=None)
+        
+        writer = MLflowSetupWriter(
+            file_manager=file_manager,
+            project_name="my_experiment"
+        )
+        writer.write_code()
+        
+        content = file_manager.mlflow_setup_path.read_text()
+        
+        # Check for setup function
+        assert "def setup_mlflow()" in content
+        assert "mlflow.set_tracking_uri" in content
+        assert "mlflow.set_experiment" in content
+        
+        # Check for main block
+        assert 'if __name__ == "__main__"' in content

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -386,3 +386,161 @@ class TestProjectRun:
         
         # Verify environ_manager was never created
         assert proj.environ_manager is None
+
+class TestProjectMLflowIntegration:
+    """Test suite for Project MLflow integration."""
+    
+    def test_project_initialization_with_mlflow_enabled(self):
+        """Test Project initialization with MLflow enabled."""
+        proj = Project(
+            name="test_project",
+            enable_mlflow=True
+        )
+        
+        assert proj.enable_mlflow is True
+        assert proj.mlflow_tracking_uri is None
+    
+    def test_project_initialization_with_mlflow_and_custom_uri(self):
+        """Test Project initialization with MLflow and custom tracking URI."""
+        proj = Project(
+            name="test_project",
+            enable_mlflow=True,
+            mlflow_tracking_uri="http://localhost:5000"
+        )
+        
+        assert proj.enable_mlflow is True
+        assert proj.mlflow_tracking_uri == "http://localhost:5000"
+    
+    @patch('bukka.project.EnvironmentBuilder')
+    @patch('bukka.project.FileManager')
+    def test_environment_builder_receives_mlflow_flag(
+        self,
+        mock_file_manager_class,
+        mock_env_builder_class
+    ):
+        """Test that EnvironmentBuilder receives enable_mlflow flag."""
+        mock_fm = MagicMock()
+        mock_file_manager_class.return_value = mock_fm
+        
+        proj = Project(name="test", enable_mlflow=True)
+        proj.run()
+        
+        # Verify EnvironmentBuilder was called with enable_mlflow=True
+        mock_env_builder_class.assert_called_once_with(
+            file_manager=mock_fm,
+            enable_mlflow=True
+        )
+    
+    @patch('bukka.project.ConfigWriter')
+    @patch('bukka.project.StarterNotebookWriter')
+    @patch('bukka.project.DataReaderWriter')
+    @patch('bukka.project.PipelineWriter')
+    @patch('bukka.project.Dataset')
+    @patch('bukka.project.EnvironmentBuilder')
+    @patch('bukka.project.PyprojectTomlWriter')
+    @patch('bukka.project.FileManager')
+    def test_write_mlflow_setup_called_when_enabled(
+        self,
+        mock_fm_class,
+        mock_toml_class,
+        mock_env_class,
+        mock_dataset_class,
+        mock_pipeline_class,
+        mock_data_reader_class,
+        mock_notebook_class,
+        mock_config_class
+    ):
+        """Test that _write_mlflow_setup is called when MLflow is enabled."""
+        # Setup mocks
+        mock_fm = MagicMock()
+        mock_fm.mlruns_path = MagicMock()
+        mock_fm.mlruns_path.mkdir = MagicMock()
+        mock_fm_class.return_value = mock_fm
+        
+        # Create a temporary dataset file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            dataset_path = f.name
+        
+        try:
+            proj = Project(
+                name="test",
+                dataset_path=dataset_path,
+                target_column="target",
+                enable_mlflow=True
+            )
+            
+            # Patch the _write_mlflow_setup method to verify it's called
+            with patch.object(proj, '_write_mlflow_setup') as mock_mlflow_setup:
+                proj.run()
+                
+                # Verify _write_mlflow_setup was called
+                mock_mlflow_setup.assert_called_once()
+        finally:
+            # Cleanup
+            Path(dataset_path).unlink(missing_ok=True)
+    
+    @patch('bukka.project.ConfigWriter')
+    @patch('bukka.project.StarterNotebookWriter')
+    @patch('bukka.project.DataReaderWriter')
+    @patch('bukka.project.PipelineWriter')
+    @patch('bukka.project.Dataset')
+    @patch('bukka.project.EnvironmentBuilder')
+    @patch('bukka.project.PyprojectTomlWriter')
+    @patch('bukka.project.FileManager')
+    def test_write_mlflow_setup_not_called_when_disabled(
+        self,
+        mock_fm_class,
+        mock_toml_class,
+        mock_env_class,
+        mock_dataset_class,
+        mock_pipeline_class,
+        mock_data_reader_class,
+        mock_notebook_class,
+        mock_config_class
+    ):
+        """Test that _write_mlflow_setup is NOT called when MLflow is disabled."""
+        # Setup mocks
+        mock_fm = MagicMock()
+        mock_fm_class.return_value = mock_fm
+        
+        # Create a temporary dataset file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            dataset_path = f.name
+        
+        try:
+            proj = Project(
+                name="test",
+                dataset_path=dataset_path,
+                target_column="target",
+                enable_mlflow=False
+            )
+            
+            # Patch the _write_mlflow_setup method to verify it's NOT called
+            with patch.object(proj, '_write_mlflow_setup') as mock_mlflow_setup:
+                proj.run()
+                
+                # Verify _write_mlflow_setup was NOT called
+                mock_mlflow_setup.assert_not_called()
+        finally:
+            # Cleanup
+            Path(dataset_path).unlink(missing_ok=True)
+    
+    @patch('bukka.coding.write_mlflow_setup.MLflowSetupWriter')
+    @patch('bukka.project.FileManager')
+    def test_write_mlflow_setup_creates_directory(
+        self,
+        mock_fm_class,
+        mock_mlflow_writer_class
+    ):
+        """Test that _write_mlflow_setup creates mlruns directory."""
+        mock_fm = MagicMock()
+        mock_mlruns_path = MagicMock()
+        mock_fm.mlruns_path = mock_mlruns_path
+        mock_fm_class.return_value = mock_fm
+        
+        proj = Project(name="test", enable_mlflow=True)
+        proj.file_manager = mock_fm
+        proj._write_mlflow_setup()
+        
+        # Verify mlruns directory creation was called
+        mock_mlruns_path.mkdir.assert_called_once_with(exist_ok=True)


### PR DESCRIPTION
Add --mlflow flag to enable MLflow experiment tracking in generated projects. When enabled, projects include MLflow setup, configuration, and mlflow>=2.0.0 in requirements.txt.

Changes:
- Add enable_mlflow and mlflow_tracking_uri config options (cli_config.py)
- Add --mlflow and --mlflow-tracking-uri CLI arguments (__main__.py)
- Update EnvironmentBuilder to conditionally install MLflow (environment.py)
- Add mlruns_path and mlflow_setup_path to FileManager (file_manager.py)
- Create MLflowSetupWriter for generating mlflow_setup.py (write_mlflow_setup.py)
- Extend ConfigWriter to include MLflow constants (write_config.py)
- Wire MLflow through Project class with _write_mlflow_setup() (project.py)
- Add comprehensive unit tests for MLflow integration
- Update CLI_GUIDE.md with MLflow documentation and examples

Features:
- Optional feature (disabled by default, requires --mlflow flag)
- Pinned MLflow version to >=2.0.0
- Default tracking URI: file:///mlruns in project directory
- Creates mlflow_setup.py with tracking configuration
- Adds MLFLOW_TRACKING_URI and MLFLOW_EXPERIMENT_NAME to config.py
- Full backward compatibility

Tests: All 10 new tests pass (4 MLflowSetupWriter + 6 Project integration)